### PR TITLE
Agregando _site a gitignore y arreglando el link del logo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+_site

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
                 <div class="nk-nav-table">
                     <div class="nk-nav-row">
 
-                        <a href="index-2.html" class="nk-nav-logo">
+                        <a href="./" class="nk-nav-logo">
                             <img src="assets/images/logo.png" alt="" width="250">
                         </a>
 


### PR DESCRIPTION
Para evitar conflictos es mejor tener el _site fuera de los commits ya que github pages lo arma el mismo. En el index el link del logo mandaba a un 404 pero con un ./ ya no tiene que salir mas. Cuando el dominio ya sea uno como toca hay que cambiarlo por /